### PR TITLE
New documentation for https://github.com/jslay88/qbt_migrate/issues/14

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Assuming all of our torrents are in `X:\Torrents` when coming from Windows, or `
     qbt_migrate -e X:\ -n Z:\ -t Windows  # Windows to Windows (Drive letter change)
     qbt_migrate -e X:\Torrents -n X:\NewDir\Torrents -t Windows  # Windows to Windows (Directory Change)
     qbt_migrate -e X:\Torrents -n Z:\NewDir\Torrents -t Windows  # Windows to Windows (Drive letter change with directory change)
-    qbt_migrate -e X:\Torrents -n /torrents -t Linux  # Windows to Linux/Mac (converts slashes)
-    qbt_migrate -e X:\\ -n /mnt/x -t Linux  # Windows to Linux/Mac (NOTE: '-e Drive_Letter:\\' requires double backslash)
+    qbt_migrate -e X:\Torrents -n /torrents/ -t Linux  # Windows to Linux/Mac (converts slashes)
+    qbt_migrate -e X:\\ -n /mnt/x/ -t Linux  # Windows to Linux/Mac (NOTE: '-e Drive_Letter:\\' requires double backslash)
     
     qbt_migrate -e /torrents -n /new/path/for/torrents  # Changes torrent root path on Linux/Mac
     qbt_migrate -e /torrents -n Z:\Torrents -t Windows  # Linux/Mac to Windows (converts slashes)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Assuming all of our torrents are in `X:\Torrents` when coming from Windows, or `
     qbt_migrate -e X:\Torrents -n X:\NewDir\Torrents -t Windows  # Windows to Windows (Directory Change)
     qbt_migrate -e X:\Torrents -n Z:\NewDir\Torrents -t Windows  # Windows to Windows (Drive letter change with directory change)
     qbt_migrate -e X:\Torrents -n /torrents -t Linux  # Windows to Linux/Mac (converts slashes)
+    qbt_migrate -e X:\\ -n /mnt/x -t Linux  # Windows to Linux/Mac (NOTE: '-e Drive_Letter:\\' requires double backslash)
     
     qbt_migrate -e /torrents -n /new/path/for/torrents  # Changes torrent root path on Linux/Mac
     qbt_migrate -e /torrents -n Z:\Torrents -t Windows  # Linux/Mac to Windows (converts slashes)


### PR DESCRIPTION
Hello, I just googled how to contributed to github to do this haha.

Thanks


(I have only tested Windows -> Linux)

(1) trailing '/' required
('-n /torrents/')

Doing:
'-n /torrents' will result in:

X:\torrents\Linux_isos\ubuntu.iso -> /torrentsLinux_isos/ubuntu.iso 


(2) only replacing 'drive_letter:\' requires double backslash
'-e X:\\ -n /mnt/x/'