### PR TITLE
qBt-savePath Fix, again

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Ignore everything
+*
+
+# Copy these files/folders
+!qbt_migrate/
+!pyproject.toml
+!LICENSE.md
+!README.md
+
+# Ignore bytecode
+**/*.pyc

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-python@v2.2.2
         if: steps.filter.outputs.python == 'true'
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Tox
         if: steps.filter.outputs.python == 'true'
@@ -71,7 +71,7 @@ jobs:
         uses: actions/setup-python@v2.2.2
         if: steps.filter.outputs.python == 'true'
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Coverage & diff_cover
         if: steps.filter.outputs.python == 'true'
@@ -109,7 +109,7 @@ jobs:
         uses: actions/setup-python@v2.2.2
         if: steps.filter.outputs.python == 'true'
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Flit
         if: steps.filter.outputs.python == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,5 @@ dmypy.json
 # Project files
 *.zip
 *.fastresume
+user_files/
 !tests/test_files/**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.10.0
     hooks:
     - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
     - id: flake8
-      additional_dependencies: [flake8-bugbear==22.1.11]
+      additional_dependencies: [flake8-bugbear==22.10.27]
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM python:3-alpine
+ARG PYTHON_VERSION="3.11"
+FROM python:${PYTHON_VERSION}-alpine
 ENV BT_BACKUP_PATH=/tmp/BT_backup
 WORKDIR /opt/qbt_migrate
-COPY qbt_migrate qbt_migrate
-COPY pyproject.toml pyproject.toml
-COPY LICENSE.md LICENSE.md
-COPY README.md README.md
+COPY . .
 RUN pip install flit
 ENV FLIT_ROOT_INSTALL=1
 RUN flit install --symlink --deps production

--- a/qbt_migrate/classes.py
+++ b/qbt_migrate/classes.py
@@ -202,6 +202,13 @@ class FastResume(object):
         save_file: bool = True,
         create_backup: bool = True,
     ):
+        self.logger.debug(f"Set Save Paths in {self.file_path}...")
+        self.logger.debug(f"path: {path}")
+        self.logger.debug(f"qbt_path: {qbt_path}")
+        self.logger.debug(f"qbt_download_path: {qbt_download_path}")
+        self.logger.debug(f"target_os: {target_os}")
+        self.logger.debug(f"save_file: {save_file}")
+        self.logger.debug(f"create_backup: {create_backup}")
         if create_backup:
             self.save(self.backup_filename)
         if not path.strip():
@@ -240,6 +247,12 @@ class FastResume(object):
         create_backup: bool = True,
     ):
         self.logger.debug(f"Replacing Paths in FastResume {self.file_path}...")
+        self.logger.debug(f"Existing Path: {existing_path}")
+        self.logger.debug(f"New Path: {new_path}")
+        self.logger.debug(f"Regex Path: {regex_path}")
+        self.logger.debug(f"Target OS: {target_os}")
+        self.logger.debug(f"Save File: {save_file}")
+        self.logger.debug(f"Create Backup: {create_backup}")
         if regex_path:
             new_save_path = None
             new_qbt_save_path = None
@@ -258,10 +271,18 @@ class FastResume(object):
         else:
             new_save_path = self.save_path.replace(existing_path, new_path) if self.save_path is not None else None
             new_qbt_save_path = (
-                self.qbt_save_path.replace(existing_path, new_path) if self.qbt_save_path is not None else None
+                self.qbt_save_path.replace(
+                    convert_slashes(existing_path, TargetOS.POSIX), convert_slashes(new_path, TargetOS.POSIX)
+                )
+                if self.qbt_save_path is not None
+                else None
             )
             new_qbt_download_path = (
-                self.qbt_download_path.replace(existing_path, new_path) if self.qbt_download_path is not None else None
+                self.qbt_download_path.replace(
+                    convert_slashes(existing_path, TargetOS.POSIX), convert_slashes(new_path, TargetOS.POSIX)
+                )
+                if self.qbt_download_path is not None
+                else None
             )
             if not self.save_path:
                 new_save_path = new_qbt_save_path

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ envlist=lint, unittest
 
 recreate=False
 
-basepython=python3.10
+basepython=python3.11
 
 deps=
     lint:       {[lint-config]deps}


### PR DESCRIPTION
Looks like `qBt-savePath` always uses Posix pathing, even for Windows. This breaks the `replace` when running on Windows original paths. 

Forcing use of Posix slashes for `qBt-savePath`. 

Closes #61 