### PR TITLE
Add --skip-backup flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install from PyPi using `pip`, or run with [Docker](#docker).
 
 Run the script and follow prompts or use CLI arguments with command `qbt_migrate`
 
-    usage: qbt_migrate [-h] [-e EXISTING_PATH] [-n NEW_PATH] [-r] [-t {Windows,Linux,Mac}] [-b BT_BACKUP_PATH] [-s] [-l {DEBUG,INFO}] [-v]
+    usage: qbt_migrate [-h] [-e EXISTING_PATH] [-n NEW_PATH] [-r] [-t {Windows,Linux,Mac}] [-b BT_BACKUP_PATH] [-s] [-z] [-l {DEBUG,INFO}] [-v]
 
     options:
       -h, --help            show this help message and exit
@@ -38,6 +38,7 @@ Run the script and follow prompts or use CLI arguments with command `qbt_migrate
       -b BT_BACKUP_PATH, --bt-backup-path BT_BACKUP_PATH
                             BT_backup Path Override.
       -s, --skip-bad-files  Skips bad .fastresume files instead of exiting. Default behavior is to exit.
+      -z, --skip-backup     Skips creating a backup zip archive of the BT_backup folder. Default behavior is to create a backup.
       -l {DEBUG,INFO}, --log-level {DEBUG,INFO}
                             Log Level, Default is INFO.
       -v, --version         Prints the current version number and exits.
@@ -50,7 +51,8 @@ Default BT_backup paths:
 * Linux/Mac: `$HOME/.local/share/data/qBittorrent/BT_backup`
 * Docker: `/config/qBittorrent/BT_backup`
 
-A backup zip archive is automatically created in the `BT_backup` directory.
+A backup zip archive is automatically created in the `BT_backup` directory by default.
+You can skip the backup creation using the `-z` or `--skip-backup` flag.
 
 ### Examples
 Assuming all of our torrents are in `X:\Torrents` when coming from Windows, or `/torrents` when coming from Linux/Mac

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core>=3.2,<4"]
+requires = ["flit_core>=3.2,<4", "bencode.py==4.0.0"]
 build-backend = "flit_core.buildapi"
 
 [project]

--- a/qbt_migrate/__init__.py
+++ b/qbt_migrate/__init__.py
@@ -1,11 +1,31 @@
 """qBt Migrate, change the paths of existing torrents in qBittorrent, as well as convert paths to Windows/Linux/Mac"""
+
 import logging
 import os
 
-from qbt_migrate.classes import FastResume, QBTBatchMove
-from qbt_migrate.methods import convert_slashes, discover_bt_backup_path
-
 
 __version__ = "2.3.2" + os.getenv("VERSION_TAG", "")
+
+
+def __getattr__(name):
+    """Lazy import to avoid circular dependencies during build."""
+    if name == "FastResume":
+        from qbt_migrate.classes import FastResume
+
+        return FastResume
+    elif name == "QBTBatchMove":
+        from qbt_migrate.classes import QBTBatchMove
+
+        return QBTBatchMove
+    elif name == "convert_slashes":
+        from qbt_migrate.methods import convert_slashes
+
+        return convert_slashes
+    elif name == "discover_bt_backup_path":
+        from qbt_migrate.methods import discover_bt_backup_path
+
+        return discover_bt_backup_path
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/qbt_migrate/cli.py
+++ b/qbt_migrate/cli.py
@@ -50,6 +50,14 @@ def parse_args(args=None):
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "-z",
+        "--skip-backup",
+        help="Skips creating a backup zip archive of the BT_backup folder. "
+        "Default behavior is to create a backup.",
+        action="store_true",
+        default=False,
+    )
 
     parser.add_argument(
         "-l",
@@ -168,7 +176,7 @@ def main():  # noqa: C901
         args.new_path,
         args.regex,
         args.target_os,
-        True,
+        not args.skip_backup,
         args.skip_bad_files,
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,6 +49,7 @@ def test_parse_args_defaults():
             "target_os",
             "bt_backup_path",
             "skip_bad_files",
+            "skip_backup",
             "log_level",
         ]
     )
@@ -58,6 +59,7 @@ def test_parse_args_defaults():
     assert args.target_os is None
     assert args.bt_backup_path is None
     assert args.skip_bad_files is False
+    assert args.skip_backup is False
     assert args.log_level == "INFO"
 
 
@@ -75,6 +77,7 @@ def test_parse_args_shorthand():
             "-b",
             "bt-backup-path",
             "-s",
+            "-z",
             "-l",
             "DEBUG",
         ]
@@ -85,6 +88,7 @@ def test_parse_args_shorthand():
     assert args.target_os == "Linux"
     assert args.bt_backup_path == "bt-backup-path"
     assert args.skip_bad_files is True
+    assert args.skip_backup is True
     assert args.log_level == "DEBUG"
 
 
@@ -102,6 +106,7 @@ def test_parse_args_longhand():
             "--bt-backup-path",
             "bt-backup-path",
             "--skip-bad-files",
+            "--skip-backup",
             "--log-level",
             "DEBUG",
         ]
@@ -112,6 +117,7 @@ def test_parse_args_longhand():
     assert args.target_os == "Linux"
     assert args.bt_backup_path == "bt-backup-path"
     assert args.skip_bad_files is True
+    assert args.skip_backup is True
     assert args.log_level == "DEBUG"
 
 
@@ -171,6 +177,7 @@ def test_main_with_args(monkeypatch):
             "-t",
             "Windows",
             "-s",
+            "-z",
         ],
     )
     main()
@@ -182,7 +189,7 @@ def test_main_with_args(monkeypatch):
     assert MockQBTBatchMove.run_call[0][1] == "different-new-path"
     assert MockQBTBatchMove.run_call[0][2] is True
     assert MockQBTBatchMove.run_call[0][3] is TargetOS.WINDOWS
-    assert MockQBTBatchMove.run_call[0][4] is True
+    assert MockQBTBatchMove.run_call[0][4] is False
     assert MockQBTBatchMove.run_call[0][5] is True
 
 


### PR DESCRIPTION
This is helpful in situations where I have already made a backup (or qbt_migrate has from a previous run) and I have to make a series of subsequent path changes, it takes a long time to create zip backups for each time when you have lots of torrents. 
So this improves UX significantly